### PR TITLE
Minor fixes to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,21 +66,21 @@ If you want to run Tiberius with softmasking, model weights will be downloaded f
 
 ```shell
 # Run Tiberius with softmasking
-python bin/tiberius.py --fasta input.fasta --out output.gtf
+python bin/tiberius.py --genome input.fasta --out output.gtf
 ```
 
 You can also manually download the weights and provide the path to the weights with the `--model` argument.
 ```shell
 wget https://bioinf.uni-greifswald.de/bioinf/tiberius/models/tiberius_weights.tgz
 tar -xzvf tiberius_weights.tgz
-python bin/tiberius.py --fasta input.fasta --out output.gtf --model path/to/tiberius_weights
+python bin/tiberius.py --genome input.fasta --out output.gtf --model path/to/tiberius_weights
 ```
 
 ### Running Tiberius without softmasked genome
 If you want to run Tiberius without softmasking, you can use the `--no_softmasking` argument. Tiberius will download the weights for the non-softmasking model automatically from https://bioinf.uni-greifswald.de/bioinf/tiberius/models/tiberius_nosm_weights.tgz into `model_weights`.
 ```shell
 # Run Tiberius without softmasking
-python bin/tiberius.py --fasta input.fasta --out output.gtf --no_softmasking
+python bin/tiberius.py --genome input.fasta --out output.gtf --no_softmasking
 ```
 
 You can also manually download the weights and provide the path to the weights with the `--model` argument. Note that in this case you have to provide the weights with `--model_lstm` to Tiberius.
@@ -88,21 +88,21 @@ You can also manually download the weights and provide the path to the weights w
 ```shell
 wget https://bioinf.uni-greifswald.de/bioinf/tiberius/models/tiberius_nosm_weights.tgz
 tar -xzvf tiberius_nosm_weights.tgz
-python bin/tiberius.py --fasta input.fasta --out output.gtf --model_lstm path/to/tiberius_nosm_weights
+python bin/tiberius.py --genome input.fasta --out output.gtf --model_lstm path/to/tiberius_nosm_weights
 ```
 
 ### Running Tiberius with evolutionary information
 To run Tiberius in *de novo* mode, evolutionary information data has to be generated with ClaMSA. See [docs/clamsa_data.md](docs/clamsa_data.md) for instructions on how to generate the data. Afterwards, you should have a directory with files named `$clamsa/{prefix}{seq_name}.npz` for each sequence of your FASTA file. You can then run Tiberius with the `--clamsa` argument. Note that your genome has to be softmasked for this mode and that you have to use different training weights than in *ab initio* mode. If not provided, they will automatically downloaded from https://bioinf.uni-greifswald.de/bioinf/tiberius/models/tiberius_denovo_weights.tgz into `model_weights`.
 ```shell
 # Run Tiberius with softmasking
-python bin/tiberius.py --fasta input.fasta --clamsa $clamsa/{prefix} --out output.gtf
+python bin/tiberius.py --genome input.fasta --clamsa $clamsa/{prefix} --out output.gtf
 ```
 You can also manually download the weights and provide the path to the weights with the `--model` argument. 
 
 ```shell
 wget https://bioinf.uni-greifswald.de/bioinf/tiberius/models/tiberius_denovo_weights.tgz
 tar -xzvf tiberius_denovo_weights.tgz
-python bin/tiberius.py --fasta input.fasta --out output.gtf --model_lstm path/to/tiberius_denovo_weights
+python bin/tiberius.py --genome input.fasta --out output.gtf --model_lstm path/to/tiberius_denovo_weights
 ```
 
 

--- a/docs/install_tensorflow.md
+++ b/docs/install_tensorflow.md
@@ -18,7 +18,7 @@ To install TensorFlow 2.10 with GPU support using Conda, follow these steps:
 2. and sign back in via SSH or close and re-open your terminal window. Reactivate your conda session and install Tensorflow.
 
     ```shell
-    conda activate tf
+    conda activate tf2_10
     python3 -m pip install tensorflow==2.10 numpy==1.24
     ```
 


### PR DESCRIPTION
Looks like the proper flag name is --genome instead of --fasta

I also had a heck of a time trying to do a "pip only install" (seems like tensorflow 2.10 is not possible to install from pypi anymore? fully pulled from that platform? maybe the pip only install should not be recommended in the README even) 

...but finally found that the conda install did help!

I am not sure if it is the case but i think there was a typo in the conda install and the intent was to re-activate the environment tf2_10 env so i added that in this PR also

