### PR TITLE
Usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ pip install pyBigWig bio scikit-learn biopython bcbio-gff requests gzip bz2
 ```
 Tensorflow should be installed with GPU support. If you are using conda, you can install Tensorflow 2.10 with these [instructions](docs/install_tensorflow.md).
 
-Tiberius does also work with TensorFlow >2.10, however, **it will produce an error if you use a `--seq_len` parameter > 259.992 during inference!**
+Tiberius does also work with TensorFlow >2.10, however, **it will produce an error if you use a `--seq_len` parameter > 259.992 during inference!**  
 You can install the current TensorFlow version with 
 ```shell
 python3 -m pip install tensorflow[and-cuda]

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ pip install pyBigWig bio scikit-learn biopython bcbio-gff requests gzip bz2
 ```
 Tensorflow should be installed with GPU support. If you are using conda, you can install Tensorflow 2.10 with these [instructions](docs/install_tensorflow.md).
 
-Tiberius does also work with TensorFlow >2.10, however, **it will produce an error if you use a sequence length > 260.000 during inference!**
+Tiberius does also work with TensorFlow >2.10, however, **it will produce an error if you use a `--seq_len` parameter > 259.992 during inference!**
 You can install the current TensorFlow version with 
 ```shell
 python3 -m pip install tensorflow[and-cuda]

--- a/bin/genome_fasta.py
+++ b/bin/genome_fasta.py
@@ -2,7 +2,7 @@ import numpy as np
 import gzip, bz2
 
 class GenomeSequences:
-    def __init__(self, fasta_file='', np_file='', chunksize=20000, overlap=1000):
+    def __init__(self, fasta_file='', genome=None, np_file='', chunksize=20000, overlap=1000):
         """Initialize the GenomeSequences object.
 
         Arguments:
@@ -12,6 +12,7 @@ class GenomeSequences:
             overlap (int): Overlap size between consecutive chunks.
         """
         self.fasta_file = fasta_file
+        self.genome = genome
         self.np_file = np_file
         self.chunksize = chunksize
         self.overlap = overlap
@@ -21,11 +22,19 @@ class GenomeSequences:
         self.one_hot_encoded = None
         self.chunks_one_hot = None 
         self.chunks_seq = None
-        if self.fasta_file:
-            self.read_fasta()        
+        if self.genome:
+            self.extract_seqarray()
+        elif self.fasta_file:
+            self.read_fasta()
         else:
             self.load_np_array(self.np_file)
-        #self.encode_sequences()
+
+    def extract_seqarray(self):
+        """Extract the sequence array from the genome object.
+        """
+        for name, seqrec in self.genome.items():
+            self.sequences.append(str(seqrec.seq))
+            self.sequence_names.append(name)
 
     def read_fasta(self):
         """Read genome sequences from a FASTA file, it can be compressed with gz or bz2.


### PR DESCRIPTION
fixes #10 
Sequence names are not interpreted from FASTA headers by Biopython, e.g. in
```
>NC_000001.11 Homo sapiens chromosome 1, GRCh38.p14 Primary Assembly
```
only `NC_000001.11` is the sequence name. The previously used full lines would likely break downstream programs that read the GTF.