### PR TITLE
Adaptive seq len

### DIFF
--- a/bin/eval_model_class.py
+++ b/bin/eval_model_class.py
@@ -236,7 +236,7 @@ class PredictionGTF:
         print ("Encoded seqs", len(fasta_object.one_hot_encoded))
 
         f_chunk, coords = fasta_object.get_flat_chunks(strand=strand, coords=True, 
-                                                       sequence_names=seq_names, adapt_chunksize=False, 
+                                                       sequence_names=seq_names, adapt_chunksize=True, 
                                                        parallel_factor = self.parallel_factor)
         if not softmask:
             f_chunk = f_chunk[:,:,:5]
@@ -551,7 +551,7 @@ class PredictionGTF:
         else:
             # LSTM prediction
             encoding_layer_pred = self.lstm_prediction(inp_chunks, clamsa_inp=clamsa_inp, save=save,
-                                                      batch_size=batch_size)   
+                                                      batch_size=batch_size)
         
         self.lstm_pred = encoding_layer_pred
         lstm_end = time.time()

--- a/bin/eval_model_class.py
+++ b/bin/eval_model_class.py
@@ -112,8 +112,6 @@ class PredictionGTF:
         Args:
             summary (bool, optional): If True, prints the model summary. Defaults to True.
         """
-        # measure time
-        start_time = time.time()
         if self.hmm and self.model_path_lstm:
             # only the lstm model is provided, use the default HMM Layer
             # if self.transformer or self.trans_lstm:
@@ -213,9 +211,6 @@ class PredictionGTF:
                 self.model.summary()
         else: 
             self.make_default_hmm()
-        end_time = time.time()
-        duration = end_time - start_time
-        print(f"Model loaded in {duration:.4f} seconds.")
     
     def adapt_batch_size(self, adapted_chunksize):
         """Adapts the batch size based on the chunk size.

--- a/bin/eval_model_class.py
+++ b/bin/eval_model_class.py
@@ -67,6 +67,7 @@ class PredictionGTF:
         """
         self.model_path = model_path 
         self.seq_len = seq_len
+        print("PredictionGTF initialized with seq_len", self.seq_len)
         self.batch_size = batch_size
         self.annot_path = annot_path
         self.genome_path = genome_path
@@ -111,6 +112,8 @@ class PredictionGTF:
         Args:
             summary (bool, optional): If True, prints the model summary. Defaults to True.
         """
+        # measure time
+        start_time = time.time()
         if self.hmm and self.model_path_lstm:
             # only the lstm model is provided, use the default HMM Layer
             # if self.transformer or self.trans_lstm:
@@ -210,6 +213,9 @@ class PredictionGTF:
                 self.model.summary()
         else: 
             self.make_default_hmm()
+        end_time = time.time()
+        duration = end_time - start_time
+        print(f"Model loaded in {duration:.4f} seconds.")
     
     def init_fasta(self,  genome_path=None, chunk_len=None):
         if genome_path is None:
@@ -226,9 +232,12 @@ class PredictionGTF:
         if strand is None:
             strand = self.strand
             
-        fasta_object.encode_sequences(seq=seq_names) 
+        fasta_object.encode_sequences(seq=seq_names)
+        print ("Encoded seqs", len(fasta_object.one_hot_encoded))
+
         f_chunk, coords = fasta_object.get_flat_chunks(strand=strand, coords=True, 
-                                                       sequence_name=seq_names)
+                                                       sequence_names=seq_names, adapt_chunksize=False, 
+                                                       parallel_factor = self.parallel_factor)
         if not softmask:
             f_chunk = f_chunk[:,:,:5]
         return f_chunk, coords

--- a/bin/genome_fasta.py
+++ b/bin/genome_fasta.py
@@ -34,7 +34,6 @@ class GenomeSequences:
     def extract_seqarray(self):
         """Extract the sequence array from the genome object.
         """
-        print ("Extracting string sequences from genome. ", len(self.genome), " sequences.")
         for name, seqrec in self.genome.items():
             self.sequences.append(str(seqrec.seq))
             self.sequence_names.append(name)

--- a/bin/genome_fasta.py
+++ b/bin/genome_fasta.py
@@ -1,5 +1,6 @@
 import numpy as np
 import gzip, bz2
+import sys
 
 class GenomeSequences:
     def __init__(self, fasta_file='', genome=None, np_file='', chunksize=20000, overlap=1000):
@@ -117,10 +118,10 @@ class GenomeSequences:
                     chunksize = min(2*self.overlap + 1, self.chunksize)
                 if parallel_factor is not None and chunksize <= parallel_factor:
                     chunksize = parallel_factor + 1
-                chunksize = 18*(1+chunksize//18) # make chunksize divisible by 2 and 9
-                print (f"Reduced chunksize to {chunksize} from {self.chunksize}")
+                chunksize = 684*(1+chunksize//684) # make chunksize divisible by 2 and 9
+                print (f"Reduced chunksize to {chunksize} from {self.chunksize}", file=sys.stderr)
 
-        chunks_one_hot = []        
+        chunks_one_hot = []
         chunk_coords = []
         for seq_name, sequence in zip(sequence_names, sequences_i):
             num_chunks = (len(sequence) - self.overlap) \
@@ -139,8 +140,7 @@ class GenomeSequences:
             
             last_chunksize = (len(sequence) - self.overlap)%(chunksize - self.overlap)
             if pad and last_chunksize > 0:
-                print ("padding length=", chunksize - last_chunksize)
-                padding = np.zeros((self.chunksize, 6),dtype=np.uint8)
+                padding = np.zeros((chunksize, 6),dtype=np.uint8)
                 padding[:,4] = 1
                 padding[0:last_chunksize] = sequence[-last_chunksize:]
                 chunks_one_hot.append(padding)
@@ -149,8 +149,7 @@ class GenomeSequences:
         if strand == '-':
             chunks_one_hot = chunks_one_hot[::-1, ::-1, [3, 2, 1, 0, 4, 5]]
             chunk_coords.reverse()
-        print ("Made one-hot stranded chunks for ", sequence_names, 
-               " with shape ", chunks_one_hot.shape)
+
         if coords:
             return chunks_one_hot, chunk_coords
         return chunks_one_hot

--- a/bin/genome_fasta.py
+++ b/bin/genome_fasta.py
@@ -1,7 +1,6 @@
 import numpy as np
 import gzip, bz2
 import math
-import sys
 
 class GenomeSequences:
     def __init__(self, fasta_file='', genome=None, np_file='', chunksize=20000, overlap=1000):

--- a/bin/genome_fasta.py
+++ b/bin/genome_fasta.py
@@ -103,14 +103,17 @@ class GenomeSequences:
         
         Returns: 
             chunks_one_hot (np.array): Flattened chunks of the specified sequence.
+            chunk_coords (list): List of coordinates of the chunks if coors is True.
+            chunksize (int): Possibly reduced size of each chunk.
         """
+        chunk_coords = None
+        chunksize = self.chunksize
 
         if not sequence_names: 
             sequence_names = self.sequence_names
         sequences_i = [self.one_hot_encoded[i] for i in sequence_names]
 
         # if all sequences are shorter than chunksize, reduce the chunksize
-        chunksize = self.chunksize
         if adapt_chunksize:
             max_len = max([len(seq) for seq in sequences_i])
             if max_len < self.chunksize:
@@ -125,7 +128,8 @@ class GenomeSequences:
                 chunksize = divisor * (1 + (chunksize - 1) // divisor)
 
         chunks_one_hot = []
-        chunk_coords = []
+        if coords:
+            chunk_coords = []
         for seq_name, sequence in zip(sequence_names, sequences_i):
             num_chunks = (len(sequence) - self.overlap) \
                 // (chunksize - self.overlap) + 1
@@ -153,6 +157,4 @@ class GenomeSequences:
             chunks_one_hot = chunks_one_hot[::-1, ::-1, [3, 2, 1, 0, 4, 5]]
             chunk_coords.reverse()
 
-        if coords:
-            return chunks_one_hot, chunk_coords
-        return chunks_one_hot
+        return chunks_one_hot, chunk_coords, chunksize

--- a/bin/tiberius.py
+++ b/bin/tiberius.py
@@ -279,8 +279,9 @@ def main():
         print ("grouping into", len(seq_groups), "groups of size", seqgroup_size)
         for k, seq in enumerate(seq_groups):
             logging.info(f'Tiberius gene predicton {k+1+len(seq_groups)*j}/{len(strand)*len(seq_groups)} ')
-            x_data, coords = pred_gtf.load_genome_data(genome_fasta, seq,
+            x_data, coords, adapted_seqlen = pred_gtf.load_genome_data(genome_fasta, seq,
                                                        softmask=softmasking, strand=s_)
+            pred_gtf.adapt_batch_size(adapted_seqlen)
             # print(x_data.shape)
             clamsa=None
             if clamsa_prefix:

--- a/bin/tiberius.py
+++ b/bin/tiberius.py
@@ -89,7 +89,7 @@ def group_sequences(seq_names, seq_lens, t=50000400, chunk_size=500004):
     """
     # Sort sequences by decreasing length, so that similar long sequences are grouped together
     # and adaptive chunk sizes are effective.
-    sorted_seqs = sorted(zip(seq_names, seq_lens), key=lambda x: x[1], reverse=True)
+    sorted_seqs = sorted(zip(seq_names, seq_lens), key=lambda x: x[1], reverse=False)
 
     groups = []
     current_group = []

--- a/bin/tiberius.py
+++ b/bin/tiberius.py
@@ -87,7 +87,7 @@ def check_file_exists(file_path):
 def group_sequences(seq_names, seq_lens, t=50000400, chunk_size=500004):
     """ Group seguences into chunks of size t, groups are shown in the progress output.
     """
-    # Sort sequences by decreasing length, so that similar long sequences are grouped together
+    # Sort sequences by increasing length, so that similar long sequences are grouped together
     # and adaptive chunk sizes are effective.
     sorted_seqs = sorted(zip(seq_names, seq_lens), key=lambda x: x[1], reverse=False)
 
@@ -276,7 +276,7 @@ def main():
         seq_groups = group_sequences(genome_fasta.sequence_names,
                                    [len(s) for s in genome_fasta.sequences],
                                     t=seqgroup_size, chunk_size=seq_len)
-        print ("grouping into", len(seq_groups), "groups of size", seqgroup_size)
+
         for k, seq in enumerate(seq_groups):
             logging.info(f'Tiberius gene predicton {k+1+len(seq_groups)*j}/{len(strand)*len(seq_groups)} ')
             x_data, coords, adapted_seqlen = pred_gtf.load_genome_data(genome_fasta, seq,

--- a/bin/write_tfrecord_species.py
+++ b/bin/write_tfrecord_species.py
@@ -59,7 +59,7 @@ def get_species_data_hmm(genome_path='', annot_path='', species='', seq_len=5000
     fasta.encode_sequences() 
     seqs = [len(s) for s in fasta.sequences]
     seq_names = fasta.sequence_names
-    f_chunk = fasta.get_flat_chunks(strand='+', pad=False)
+    f_chunk, _, _ = fasta.get_flat_chunks(strand='+', pad=False)
     del fasta
     print(f_chunk.shape)
     full_f_chunks = np.concatenate((f_chunk[::-1,::-1, [3,2,1,0,4,5]], 


### PR DESCRIPTION
The `seq_len`/`chunk_size` is reduced to the maximum contig length if that is shorter.
It remains a multiple of 2, 9 and parallel_factor.
The `batch_size` is enlarged like this:
`adapted_batch_size = batch_size * chunk_size // adapted_chunksize`
and then rounded down to nearest power of 2.

On a very fragmented primate genome assembly the original code took an estimated 62h on  single A100.
With these changes, the new code takes only 1.5h.
