### PR TITLE
Add container label in hc.nf

### DIFF
--- a/tiberius/modules/hc.nf
+++ b/tiberius/modules/hc.nf
@@ -1,7 +1,8 @@
 nextflow.enable.dsl=2
 
 process HC_SUPPORTED {
-  // publishDir "${params.outdir}", pattern: "hc/*", mode: 'copy'
+    label 'container'
+// publishDir "${params.outdir}", pattern: "hc/*", mode: 'copy'
   
   input:
     path diamond_revised


### PR DESCRIPTION
Loos like a container label is missing in hc.nf, process HC_SUPPORTED. Different tools available in the image are called, but no container label is present. In my case I get:
```
ERROR ~ Error executing process > 'HC_GENES:HC_SUPPORTED' Caused by: Process `HC_GENES:HC_SUPPORTED` terminated with an error exit status (1)

Command executed:

  mkdir -p hc
  python3 /data/fg1930/Tiberius/tiberius/scripts/generate_hc_genes.py --diamond_revised diamond.tsv --revised_pep revised_candidates.pep --proteins protein_preprocessed.fa --stringtie_gtf stringtie.gtf --stringtie_gff3 stringtie.gff3 --transcripts_fasta transcripts.fasta --miniprot_gff miniprot_parsed.gff --transdecoder_util cdna_alignment_orf_to_genome_orf.pl --bedtools_path bedtools     --outdir hc
Command exit status:
  1

Command output:
  (empty)

Command error:
  ERROR:root:Unexpected error while running subprocess: [Errno 2] No such file or directory: 'cdna_alignment_orf_to_genome_orf.pl'
  ERROR:root:Command: cdna_alignment_orf_to_genome_orf.pl hc/intrinsic_candidates.gff3 stringtie.gff3 transcripts.fasta
  Traceback (most recent call last):
    File "/data/fg1930/Tiberius/tiberius/scripts/utility.py", line 149, in run_subprocess
      result = subprocess.run(command, capture_output=capture_output, text=text, check=check,
    File "/usr/lib/python3.10/subprocess.py", line 503, in run
      with Popen(*popenargs, **kwargs) as process:
    File "/usr/lib/python3.10/subprocess.py", line 971, in __init__
      self._execute_child(args, executable, preexec_fn, close_fds,
    File "/usr/lib/python3.10/subprocess.py", line 1863, in _execute_child
      raise child_exception_type(errno_num, err_msg, err_filename)
  FileNotFoundError: [Errno 2] No such file or directory: 'cdna_alignment_orf_to_genome_orf.pl'

  The above exception was the direct cause of the following exception:

  Traceback (most recent call last): File "/data/fg1930/Tiberius/tiberius/scripts/generate_hc_genes.py", line 26, in <module>
      hc_pep, lc_genes = getting_hc_supported_by_intrinsic(
    File "/data/fg1930/Tiberius/tiberius/scripts/hc_module.py", line 625, in getting_hc_supported_by_intrinsic
      from_transcript_to_genome(intrinsic_gff3, stringtie_gff, transcript_fasta,
    File "/data/fg1930/Tiberius/tiberius/scripts/hc_module.py", line 319, in from_transcript_to_genome
      run_subprocess(command, stdout=output, capture_output=False,
    File "/data/fg1930/Tiberius/tiberius/scripts/utility.py", line 168, in run_subprocess
      raise RuntimeError(f"{error_message}: {e}") from e
  RuntimeError: TransDecoder coordinate transformation failed.: [Errno 2] No such file or directory: 'cdna_alignment_orf_to_genome_orf.pl'
```
Adding the container label fixes this issue for me.