### PR TITLE
Issues

### DIFF
--- a/conf/base.config
+++ b/conf/base.config
@@ -64,7 +64,7 @@ process {
 // Container label: turn on container usage and set image from params.container
 process {
   withLabel: container {
-    container = "docker://larsgabriel23/tiberius:2.0.5"
+    container = "docker://larsgabriel23/tiberius:2.0.6"
   }
 
   // High-memory tasks

--- a/conf/base.config
+++ b/conf/base.config
@@ -105,7 +105,7 @@ singularity {
   autoMounts   = true
   envWhitelist = 'CUDA_VISIBLE_DEVICES'
   pullTimeout = "60m"
-  execOptions = '--contain'
+  runOptions = '--contain'
 
 }
 

--- a/conf/base.config
+++ b/conf/base.config
@@ -17,9 +17,14 @@ params {
   rnaseq_paired     = []
   isoseq            = []
   tiberius {
-    run       = false
-    result    = null
-    model_cfg = null
+    run          = false
+    result       = null
+    model_cfg    = null
+    // Cap concurrent RUN_TIBERIUS forks (e.g. 1 on a single-GPU workstation).
+    max_parallel = null
+    // Forward to per-chunk tiberius.py; null = let tiberius auto-decide.
+    batch_size   = null
+    seq_len      = null
   }
   mode = null
   scoring_matrix = "${projectDir}/../conf/blosum62.csv"

--- a/conf/greifswald_hpc.config
+++ b/conf/greifswald_hpc.config
@@ -7,7 +7,6 @@ process {
   cpus            = 60
   memory          = '60 GB'
   time            = '24h'
-  nodes           = 1
   stageInMode     = 'symlink'
   clusterOptions = '--gpus=0 --get-user-env'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tiberius"
-version = "2.0.5"
+version = "2.0.6"
 authors = [
   { name="Lars Gabriel", email="lgabriel23@gmx.de" },
   { name="Felix Becker", email="beckerfelix94@gmail.com" },

--- a/tiberius.py
+++ b/tiberius.py
@@ -135,7 +135,12 @@ def collect_cli_params(args) -> dict:
     maybe_set("genome", args.genome)
     maybe_set("proteins", args.proteins if args.proteins else None)
     maybe_set("rnaseq_single", args.rnaseq_single if args.rnaseq_single else None)
-    maybe_set("rnaseq_paired", args.rnaseq_paired if args.rnaseq_paired else None)
+    # A 1-element CLI list is a glob string; the pipeline's paired-end channel
+    # expects a CharSequence in glob mode, not a list.
+    rnaseq_paired_val = args.rnaseq_paired or None
+    if isinstance(rnaseq_paired_val, list) and len(rnaseq_paired_val) == 1:
+        rnaseq_paired_val = rnaseq_paired_val[0]
+    maybe_set("rnaseq_paired", rnaseq_paired_val)
     maybe_set("rnaseq_sra_single", args.rnaseq_sra_single if args.rnaseq_sra_single else None)
     maybe_set("rnaseq_sra_paired", args.rnaseq_sra_paired if args.rnaseq_sra_paired else None)
     maybe_set("isoseq", args.isoseq if args.isoseq else None)

--- a/tiberius.py
+++ b/tiberius.py
@@ -168,6 +168,10 @@ def collect_cli_params(args) -> dict:
         tib["model_cfg"] = args.model_cfg
     if args.tiberius_result:
         tib["result"] = args.tiberius_result
+    if args.batch_size:
+        tib["batch_size"] = args.batch_size
+    if args.seq_len:
+        tib["seq_len"] = args.seq_len
     if tib:
         tib["run"] = True
         overrides["tiberius"] = tib

--- a/tiberius.py
+++ b/tiberius.py
@@ -179,9 +179,14 @@ def ensure_params_yaml(args):
     if not params.get("genome"):
         console.print("[bold red]A genome file must be specified (via --genome or params).[/bold red]")
         sys.exit(1)
-    if params.get("tiberius", {}).get("run") and not params.get("tiberius", {}).get("model_cfg"):
-        console.print("[bold red]A model config file must be specified (params.tiberius.model_cfg or --model_cfg).[/bold red]")
-        sys.exit(1)
+    tiberius_cfg = params.get("tiberius") or {}
+    if tiberius_cfg.get("run"):
+        if not tiberius_cfg.get("model_cfg"):
+            console.print("[bold red]A model config file must be specified (params.tiberius.model_cfg or --model_cfg).[/bold red]")
+            sys.exit(1)
+        # Resolve bare names (e.g. 'angiosperms') so the Nextflow process can stage the file.
+        tiberius_cfg["model_cfg"] = str(resolve_model_cfg(tiberius_cfg["model_cfg"]))
+        params["tiberius"] = tiberius_cfg
 
     outdir = params.get("outdir") or DEFAULT_PARAMS["outdir"]
     outdir_path = Path(outdir)

--- a/tiberius.py
+++ b/tiberius.py
@@ -363,10 +363,13 @@ def run_tiberius_in_singularity(args):
     cmd = ["singularity", "run"]
     if has_nvidia_container_cli() and singularity_supports_nvccli():
         cmd += ["--nvccli"]
-    cuda_visible = os.environ.get("CUDA_VISIBLE_DEVICES", "")
+    cmd += ["--nv"]
+    # Only forward CUDA_VISIBLE_DEVICES when explicitly set; passing an empty
+    # value hides all GPUs from the container (issue #105).
+    cuda_visible = os.environ.get("CUDA_VISIBLE_DEVICES")
+    if cuda_visible:
+        cmd += ["--env", f"CUDA_VISIBLE_DEVICES={cuda_visible}"]
     cmd += [
-        "--nv",
-        "--env", f"CUDA_VISIBLE_DEVICES={cuda_visible}",
         "--cleanenv",
         str(image_path), "/usr/bin/python3",
         "/opt/Tiberius/tiberius.py"

--- a/tiberius.py
+++ b/tiberius.py
@@ -72,6 +72,20 @@ def has_nvidia_container_cli() -> bool:
     return True
 
 
+def singularity_supports_nvccli() -> bool:
+    # --nvccli requires Singularity >= 3.9 / Apptainer >= 1.0 built with nvccli support.
+    try:
+        result = subprocess.run(
+            ["singularity", "run", "--help"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return False
+    return "--nvccli" in (result.stdout + result.stderr)
+
+
 def load_params_yaml(params_path: str) -> tuple[Path, dict]:
     """Load a params YAML file and return (path, data)."""
     params_file = Path(params_path).expanduser().resolve()
@@ -343,7 +357,7 @@ def run_tiberius_in_singularity(args):
             "Pass --cleanup_old_singularity_images to remove them.[/yellow]"
         )
     cmd = ["singularity", "run"]
-    if has_nvidia_container_cli():
+    if has_nvidia_container_cli() and singularity_supports_nvccli():
         cmd += ["--nvccli"]
     cuda_visible = os.environ.get("CUDA_VISIBLE_DEVICES", "")
     cmd += [

--- a/tiberius/evidence_pipeline_wrapper.py
+++ b/tiberius/evidence_pipeline_wrapper.py
@@ -57,13 +57,14 @@ GENERAL_COMMANDS = {
     "java": "Java runtime (version 11 or newer)",
     "singularity": "Singularity/Apptainer runtime",
     "python3": "System Python 3 interpreter",
-    "perl": "Perl interpreter (needed for aln2hints.pl)",
-    "fasterq-dump": "SRA Toolkit fasterq-dump utility",
 }
 
+# Checked only with --check_tools (i.e. when not relying on the container).
 OPTIONAL_COMMANDS = {
     "prefetch": "SRA Toolkit prefetch utility (optional but recommended for SRA downloads)",
 }
+
+SRA_INPUT_KEYS = ("rnaseq_sra_single", "rnaseq_sra_paired", "isoseq_sra")
 
 
 def _default_repo_root() -> Path:
@@ -281,6 +282,10 @@ def validate_executables(
     if check_tool_binaries:
         for cmd, desc in OPTIONAL_COMMANDS.items():
             check_command(cmd, desc, mandatory=False)
+        if any(params.get(k) for k in SRA_INPUT_KEYS):
+            check_command("fasterq-dump", "SRA Toolkit fasterq-dump utility")
+        if params.get("proteins"):
+            check_command("perl", "Perl interpreter (needed for aln2hints.pl)")
         tools = build_tool_command_map(params)
         for key, cmd in tools.items():
             label = TOOL_DESCRIPTIONS.get(key, f"Tool '{key}'")

--- a/tiberius/main.nf
+++ b/tiberius/main.nf
@@ -20,9 +20,8 @@ def inferMode(boolean hasPaired, boolean hasSingle, boolean hasIso, boolean hasB
 }
 
 workflow {
-  OUT_CH = null
-
   main:
+    def OUT_CH = null
     def outdir = params.outdir ?: "results"
     file(outdir).mkdirs()
 

--- a/tiberius/main.nf
+++ b/tiberius/main.nf
@@ -103,7 +103,4 @@ workflow {
 
       OUT_CH = all_hints.hints
     }
-
-  emit:
-    OUT_CH
 }

--- a/tiberius/modules/proteins.nf
+++ b/tiberius/modules/proteins.nf
@@ -50,8 +50,9 @@ process MINIPROTHINT_CONVERT {
 }
 
 process ALN2HINTS {
-  input: path gtf
   label 'container'
+
+  input: path gtf
   output: path "hints_protein.gff", emit: hints
 
   script: """

--- a/tiberius/modules/rnaseq.nf
+++ b/tiberius/modules/rnaseq.nf
@@ -1,6 +1,10 @@
 nextflow.enable.dsl=2
 process HISAT2_BUILD {
   label 'container', 'bigmem'
+  // hisat2-build segfaults with very high thread counts on large genomes;
+  // cap at 32, but honour a lower params.threads if the user set one.
+  cpus { Math.min((params.threads ?: 32) as Integer, 32) }
+
   input:
     path genome
 

--- a/tiberius/modules/tiberius.nf
+++ b/tiberius/modules/tiberius.nf
@@ -1,5 +1,8 @@
 process RUN_TIBERIUS {
     label 'gpu', 'container', 'bigmem'
+    // Cap concurrent GPU tasks; set params.tiberius.max_parallel to e.g. 1
+    // on single-GPU workstations to avoid GPU OOM from parallel chunks.
+    maxForks { params.tiberius?.max_parallel ? (params.tiberius.max_parallel as Integer) : Integer.MAX_VALUE }
 
     memory '180 GB'
     input:
@@ -10,11 +13,14 @@ process RUN_TIBERIUS {
         path "tiberius.${genome.name}.gtf"
 
     script:
+    def extra = ''
+    if (params.tiberius?.batch_size) extra += " --batch_size ${params.tiberius.batch_size}"
+    if (params.tiberius?.seq_len)    extra += " --seq_len ${params.tiberius.seq_len}"
     """
-    tiberius.py \
-        --genome ${genome} \
-        --model_cfg ${model_cfg}\
-        --out tiberius.${genome.name}.gtf
+    tiberius.py \\
+        --genome ${genome} \\
+        --model_cfg ${model_cfg} \\
+        --out tiberius.${genome.name}.gtf${extra}
     """
 }
 

--- a/tiberius/modules/util.nf
+++ b/tiberius/modules/util.nf
@@ -12,7 +12,34 @@ process CONCAT_PROTEINS {
   shell:
   def input_str = proteins instanceof List ? proteins.join(" ") : proteins
   """
-    cat ${input_str} > proteins_concat.faa
+    : > proteins_concat.faa
+    for f in ${input_str}; do
+      if [[ "\$f" == *.gz ]]; then
+        gunzip -c "\$f" >> proteins_concat.faa
+      else
+        cat "\$f" >> proteins_concat.faa
+      fi
+    done
+  """
+}
+
+process DECOMPRESS_FASTA {
+  tag { infile.name }
+  label 'local_only'
+
+  input:
+  path infile
+
+  output:
+  path "decompressed.fa"
+
+  script:
+  """
+  if [[ "${infile.name}" == *.gz ]]; then
+    gunzip -c ${infile} > decompressed.fa
+  else
+    ln -sf \$(readlink -f ${infile}) decompressed.fa
+  fi
   """
 }
 

--- a/tiberius/modules/util.nf
+++ b/tiberius/modules/util.nf
@@ -75,6 +75,7 @@ process CALC_ALIGNMENT_RATE {
     output:
     tuple path(aln_file), path("alignment_rate.txt")
 
+    script:
     """
     pct=\$(samtools flagstat ${aln_file} \\
         | awk '/ mapped \\(/ {

--- a/tiberius/modules/util.nf
+++ b/tiberius/modules/util.nf
@@ -55,10 +55,10 @@ process CONCAT_HINTS {
 }
 
 process EMPTY_FILE {
+  label 'local_only'
+
   output:
     path 'empty.txt'
-
-  label 'local_only'
 
   script:
   """

--- a/tiberius/scripts/extend_cds_with_stop_codon.py
+++ b/tiberius/scripts/extend_cds_with_stop_codon.py
@@ -23,6 +23,24 @@ from collections import defaultdict
 
 # ------------ Helpers ------------ #
 
+def merge_intervals(intervals):
+    """Merge overlapping OR adjacent (1-based inclusive) intervals.
+
+    Two intervals are merged when a.end + 1 >= b.start, so a CDS that ends one
+    base before a UTR begins collapses into a single exon.
+    """
+    if not intervals:
+        return []
+    sorted_iv = sorted(intervals)
+    merged = [list(sorted_iv[0])]
+    for s, e in sorted_iv[1:]:
+        if s <= merged[-1][1] + 1:
+            merged[-1][1] = max(merged[-1][1], e)
+        else:
+            merged.append([s, e])
+    return [(s, e) for s, e in merged]
+
+
 def parse_attributes(attr_str: str) -> dict:
     """Parse GFF3 attributes column into a dict."""
     attrs = {}
@@ -343,30 +361,37 @@ def rebuild_gff(genes, transcripts, cds_by_tx, utrs_by_tx, gene_children, out_ha
             # sort by genomic coord
             cds_list_sorted = sorted(cds_list, key=lambda f: (f.start, f.end))
 
-            exon_counter = 1
-            cds_counter = 1
+            # Exons span the union of CDS and UTR intervals: a UTR that abuts a
+            # CDS segment (UTR.start == CDS.end + 1, or vice versa) belongs to
+            # the same exon as the CDS.
+            utr_list = utrs_by_tx.get(tx_id, [])
+            cds_intervals = [(f.start, f.end) for f in cds_list_sorted]
+            utr_intervals = [(f.start, f.end) for f in utr_list]
+            exon_intervals = merge_intervals(cds_intervals + utr_intervals)
 
-            for cds_feat in cds_list_sorted:
-                # exon (still exactly matching CDS)
+            template = cds_list_sorted[0]
+            exon_counter = 1
+            for s, e in exon_intervals:
                 exon_attrs = {
                     "ID": f"{tx_id}.exon{exon_counter}",
                     "Parent": tx_id,
                 }
                 exon = Feature(
-                    seqid=cds_feat.seqid,
-                    source=cds_feat.source,
+                    seqid=template.seqid,
+                    source=template.source,
                     ftype="exon",
-                    start=cds_feat.start,
-                    end=cds_feat.end,
-                    score=cds_feat.score,
-                    strand=cds_feat.strand,
+                    start=s,
+                    end=e,
+                    score=".",
+                    strand=template.strand,
                     phase=".",  # exon has no phase
                     attrs=exon_attrs,
                 )
                 out_handle.write("\t".join(exon.to_gff_row()) + "\n")
                 exon_counter += 1
 
-                # CDS
+            cds_counter = 1
+            for cds_feat in cds_list_sorted:
                 cds_attrs = dict(cds_feat.attrs)  # copy
                 cds_attrs["Parent"] = tx_id
                 cds_attrs.setdefault("ID", f"{tx_id}.cds{cds_counter}")

--- a/tiberius/scripts/merge_annotations.py
+++ b/tiberius/scripts/merge_annotations.py
@@ -244,7 +244,11 @@ def parse_transcripts_from_file(path: str, source_index: int) -> List[Transcript
             if not tid:
                 continue
 
-            internal_id = f"{source_index}:{tid}"
+            # Include seqid + strand in the key because some annotation tools
+            # (e.g. Tiberius) reuse transcript IDs across chromosomes within a
+            # single file. Without these, exons from unrelated loci would be
+            # merged into one synthetic transcript with a spurious mega-span.
+            internal_id = f"{source_index}:{seqid}:{strand}:{tid}"
             if internal_id not in tx_map:
                 tx_map[internal_id] = Transcript(
                     internal_id=internal_id,

--- a/tiberius/subworkflows/inputs.nf
+++ b/tiberius/subworkflows/inputs.nf
@@ -1,8 +1,10 @@
 nextflow.enable.dsl=2
 
-include { 
-    CONCAT_PROTEINS as CONCAT_PROTEINS_1 
+include {
+    CONCAT_PROTEINS as CONCAT_PROTEINS_1
     CONCAT_PROTEINS as CONCAT_PROTEINS_2
+    DECOMPRESS_FASTA as DECOMPRESS_GENOME
+    DECOMPRESS_FASTA as DECOMPRESS_SINGLE_PROTEIN
     DOWNLOAD_ODB12_PARTITIONS} from '../modules/util.nf'
 
 
@@ -16,7 +18,9 @@ workflow INPUTS {
     if( !params_map.genome ) error "params.genome is required"
     def genomeFile = file(params_map.genome)
     if( !genomeFile.exists() ) error "Genome file not found: ${genomeFile}"
-    CH_GENOME = nextflow.Channel.value(genomeFile)
+    CH_GENOME = genomeFile.name.toLowerCase().endsWith('.gz') \
+        ? DECOMPRESS_GENOME(nextflow.Channel.value(genomeFile)) \
+        : nextflow.Channel.value(genomeFile)
 
     // ---- proteins ----
     CH_PROTEINS = nextflow.Channel.empty()
@@ -29,7 +33,10 @@ workflow INPUTS {
         proteinsFiles = proteinsList.collect { file(it) }
         proteinsFiles.each { if( !it.exists() ) error "Proteins file not found: ${it}" }
         if( proteinsFiles.size() == 1 ) {
-            localProteinsCh = nextflow.Channel.value(proteinsFiles[0])
+            def singleProt = proteinsFiles[0]
+            localProteinsCh = singleProt.name.toLowerCase().endsWith('.gz') \
+                ? DECOMPRESS_SINGLE_PROTEIN(nextflow.Channel.value(singleProt)) \
+                : nextflow.Channel.value(singleProt)
         } else if( proteinsFiles.size() > 1 ) {
             localProteinsCh = CONCAT_PROTEINS_1(nextflow.Channel.value(proteinsFiles))
         }

--- a/tiberius/subworkflows/isoseq_evidence.nf
+++ b/tiberius/subworkflows/isoseq_evidence.nf
@@ -18,34 +18,36 @@ workflow ISOSEQ_EVIDENCE {
     def DO_ISO_LOCAL = params_map.isoseq && params_map.isoseq.size() > 0
     def DO_ISO = DO_ISO_LOCAL || (params_map.isoseq_sra && params_map.isoseq_sra.size() > 0)
 
-    if( !DO_ISO ) {
-        emit:
-        hints = empty_file
-        asm_gtf = Channel.empty()
-        asm_gff3 = Channel.empty()
-        return
+    def hints_out    = empty_file
+    def asm_gtf_out  = Channel.empty()
+    def asm_gff3_out = Channel.empty()
+
+    if( DO_ISO ) {
+        CH_ISO_LOCAL = DO_ISO_LOCAL ? Channel.fromPath(params_map.isoseq, checkIfExists:true) : Channel.empty()
+
+        CH_ISO = CH_ISO_LOCAL
+        if( params_map.isoseq_sra ) {
+            CH_ISO_SRA_IDS = Channel.from(params_map.isoseq_sra)
+            CH_RNASEQ_ISO_SRA = DOWNLOAD_SRA_ISOSEQ(CH_ISO_SRA_IDS)
+            CH_ISO = CH_ISO_LOCAL.mix(CH_RNASEQ_ISO_SRA.map { acc, f -> f })
+        }
+
+        iso_bam  = MINIMAP2_MAP(CH_GENOME, CH_ISO)
+        FILTER_ISOSEQ(iso_bam.bam)
+
+        iso_bams = Channel.empty().mix(FILTER_ISOSEQ.out)
+        stringtie_isoseq = STRINGTIE_ASSEMBLE_ISO(iso_bams)
+
+        iso_merged = SAMTOOLS_MERGE_ISO(iso_bams.collect())
+        iso_hints  = BAM2HINTS_ISO(iso_merged.bam, CH_GENOME)
+
+        hints_out    = iso_hints.hints
+        asm_gtf_out  = stringtie_isoseq.gtf
+        asm_gff3_out = stringtie_isoseq.gff3
     }
-
-    CH_ISO_LOCAL = DO_ISO_LOCAL ? Channel.fromPath(params_map.isoseq, checkIfExists:true) : Channel.empty()
-
-    CH_ISO = CH_ISO_LOCAL
-    if( params_map.isoseq_sra ) {
-        CH_ISO_SRA_IDS = Channel.from(params_map.isoseq_sra)
-        CH_RNASEQ_ISO_SRA = DOWNLOAD_SRA_ISOSEQ(CH_ISO_SRA_IDS)
-        CH_ISO = CH_ISO_LOCAL.mix(CH_RNASEQ_ISO_SRA.map { acc, f -> f })
-    }
-
-    iso_bam  = MINIMAP2_MAP(CH_GENOME, CH_ISO)
-    FILTER_ISOSEQ(iso_bam.bam)
-
-    iso_bams = Channel.empty().mix(FILTER_ISOSEQ.out)
-    stringtie_isoseq = STRINGTIE_ASSEMBLE_ISO(iso_bams)
-
-    iso_merged = SAMTOOLS_MERGE_ISO(iso_bams.collect())
-    iso_hints  = BAM2HINTS_ISO(iso_merged.bam, CH_GENOME)
 
     emit:
-    hints   = iso_hints.hints
-    asm_gtf = stringtie_isoseq.gtf
-    asm_gff3= stringtie_isoseq.gff3
+    hints    = hints_out
+    asm_gtf  = asm_gtf_out
+    asm_gff3 = asm_gff3_out
 }

--- a/tiberius/subworkflows/protein_evidence.nf
+++ b/tiberius/subworkflows/protein_evidence.nf
@@ -5,13 +5,6 @@ include { RUN_TIBERIUS; SPLIT_GENOME; PROTEIN_FROM_GFF; MERGE_TIBERIUS; MERGE_TI
 
 workflow PROTEIN_EVIDENCE {
 
-    // Declare in workflow scope so emit: can access them
-    def proteindb_ch
-    def tiberius_gff_ch = Channel.empty()
-    def scored_ch
-    def prot_gtf_ch
-    def prot_hints_ch
-
     take:
     CH_GENOME
     CH_PROTEINS
@@ -19,6 +12,12 @@ workflow PROTEIN_EVIDENCE {
     params_map
 
     main:
+    def proteindb_ch
+    def tiberius_gff_ch = Channel.empty()
+    def scored_ch
+    def prot_gtf_ch
+    def prot_hints_ch
+
     if( !params_map.proteins && !params_map.odb12Partitions ) {
         error "params.proteins or params.odb12Partitions is required for protein evidence modes"
     }

--- a/tiberius/subworkflows/rnaseq_evidence.nf
+++ b/tiberius/subworkflows/rnaseq_evidence.nf
@@ -25,13 +25,11 @@ workflow RNASEQ_EVIDENCE {
 
     def DO_BAM = params_map.rnaseq_bam && params_map.rnaseq_bam.size() > 0
 
-    if( !(DO_SE || DO_PE || DO_BAM) ) {
-        emit:
-        hints = empty_file
-        asm_gtf = Channel.empty()
-        asm_gff3 = Channel.empty()
-        return
-    }
+    def hints_out    = empty_file
+    def asm_gtf_out  = Channel.empty()
+    def asm_gff3_out = Channel.empty()
+
+    if( DO_SE || DO_PE || DO_BAM ) {
 
     // Build channels (local + SRA)
     CH_PAIRED_LOCAL = Channel.empty()
@@ -151,8 +149,13 @@ Got: ${pe?.getClass()?.simpleName} -> ${pe}"""
     rnaseq_merged = SAMTOOLS_MERGE_RNA(rnaseq_bams.collect())
     rnaseq_hints  = BAM2HINTS_RNA(rnaseq_merged.bam, CH_GENOME)
 
+    hints_out    = rnaseq_hints.hints
+    asm_gtf_out  = asm.gtf
+    asm_gff3_out = asm.gff3
+    }
+
     emit:
-    hints   = rnaseq_hints.hints
-    asm_gtf = asm.gtf
-    asm_gff3= asm.gff3
+    hints    = hints_out
+    asm_gtf  = asm_gtf_out
+    asm_gff3 = asm_gff3_out
 }


### PR DESCRIPTION
- Compatible with Nextflow 26.x 
- Gzipped genome and protein FASTA inputs now accepted 
- `hisat2-build` thread count capped 
- New `params.tiberius.max_parallel`, `batch_size`, `seq_len` 
- `extend_cds_with_stop_codon.py` now emits exons spanning CDS + UTR instead of
  CDS-only intervals (#103).
- `--rnaseq_paired "RNA/*_{1,2}.fastq"` on the CLI is now recognized as a glob
- `tiberius.model_cfg` in `params.yaml` accepts short names (e.g. `angiosperms`)
  and resolves them before launching Nextflow.
- `--nvccli` only forwarded to Singularity when supported (#95).